### PR TITLE
Add RDF Compatibility section recommending urn:solid as default vocab

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,17 @@ LION is a simple subset of JSON-LD, designed to avoid most of its complexity and
 
 @context is optional. It provides full compatibility with JSON-LD and and maps various items in the object to URLs in a more readable way.
 
+## RDF Compatibility
+
+LION is a subset of JSON-LD 1.1 and offers a full upgrade path to RDF. When a LION document does not supply an explicit `@context`, processors that need to emit or consume RDF (JSON-LD, Turtle, N-Triples, or any other RDF serialisation) **SHOULD** assume `@vocab: "urn:solid:"` as the default vocabulary.
+
+This gives LION documents a stable, vocabulary-agnostic surface for RDF interoperability without forcing any single upstream vocabulary on document authors. Bare property names (`name`, `knows`, `email`) expand to `urn:solid:name`, `urn:solid:knows`, `urn:solid:email`, each of which carries an `owl:sameAs` mapping to the corresponding canonical IRI in FOAF, Schema.org, dcterms, ActivityStreams, and other common vocabularies.
+
+- Registry: https://urn-solid.github.io/
+- Namespace specification: https://urn-solid.github.io/spec/
+
+Authors who supply an explicit `@context` override this default — the SHOULD applies only when no `@context` is present. LION documents that never round-trip to RDF are unaffected.
+
 ## Spec
 
 Full details on @id, @type and @context can be found in [here](https://w3c.github.io/json-ld-syntax/#syntax-tokens-and-keywords)


### PR DESCRIPTION
Implements the proposal in #5.

## Summary

Adds a new \`## RDF Compatibility\` subsection to the README, between \`@context\` and \`Spec\`, spelling out the (previously unstated) behaviour LION processors SHOULD adopt when emitting or consuming RDF:

> When a LION document does not supply an explicit \`@context\`, processors that need to emit or consume RDF (JSON-LD, Turtle, N-Triples, or any other RDF serialisation) **SHOULD** assume \`@vocab: \"urn:solid:\"\` as the default vocabulary.

## Why

- LION's pitch is \"just JSON, RDF when you need it,\" but the spec is currently silent on what default vocabulary an RDF processor should assume. This forces every author who wants RDF interop to either learn JSON-LD or accept that bare names don't expand to anything semantically meaningful.
- \`urn:solid\` is a vocabulary-agnostic URN namespace with a stable registry (~430 terms) of bare-form identifiers that map (via \`owl:sameAs\`) to canonical upstream IRIs in FOAF, Schema.org, dcterms, ActivityStreams, PROV, LDP, WAC, and SKOS/DCAT/ORG.
- Defaulting to it lets LION stay neutral on which upstream vocabulary \"wins\" while still giving RDF consumers a single, predictable expansion target.

## Why SHOULD (not MAY / MUST)

- **MAY** would be useless guidance — implementers wouldn't know what to actually do.
- **MUST** would break the \"just JSON\" framing.
- **SHOULD** gives a clear default while leaving an explicit \`@context\` as a clean override.

## Scope of impact

- Authors who never round-trip to RDF: zero change.
- Authors who supply an explicit \`@context\`: zero change (override).
- RDF processors: gain a documented default to assume.

## Reciprocal blessing

The urn:solid spec already includes a matching Compatibility section pointing back at LION: https://urn-solid.github.io/spec/#compatibility

## Test plan

- [ ] Render the README and confirm the new section renders cleanly between \`@context\` and \`Spec\`.
- [ ] Verify links to https://urn-solid.github.io/ and https://urn-solid.github.io/spec/ resolve.